### PR TITLE
fix segfault in split_header_from_body()

### DIFF
--- a/mailarchiver.c
+++ b/mailarchiver.c
@@ -89,7 +89,7 @@ split_header_from_body(char *msg, size_t length, char **body)
 {
 	char *pos = msg;
 
-	while ((pos = memchr(pos, '\n', length))) {
+	while ((pos = memchr(pos, '\n', length - (pos - msg)))) {
 		pos++;
 		if (pos < msg + length && pos[0] == '\n') {
 			*pos = '\0';


### PR DESCRIPTION
independently of the position, memchr was scanning the same amount of
bytes and on malformed mails with no body it was causing a segmentation
fault